### PR TITLE
Remove ubuntu-slim from picker

### DIFF
--- a/.github/workflows/ngrok-ubuntu.yml
+++ b/.github/workflows/ngrok-ubuntu.yml
@@ -11,7 +11,6 @@ on:
         options:
         - ubuntu-24.04
         - ubuntu-22.04
-        - ubuntu-slim
 
 jobs:
   ngrok_ssh_tunnel:


### PR DESCRIPTION
I included it in the picker since it was available, but upon attempting I found it didn't work. I have no need for it right now and no interest in figuring it out, so dropping for now.
