### PR TITLE
Drop macos-14-large since it costs

### DIFF
--- a/.github/workflows/ngrok-macos.yml
+++ b/.github/workflows/ngrok-macos.yml
@@ -12,7 +12,6 @@ on:
         - macos-15
         - macos-15-intel
         - macos-14
-        - macos-14-large
 
 jobs:
   ngrok_ssh_tunnel:


### PR DESCRIPTION
When attempting to run on `macos-14-large`, I got the error:

```
The job was not started because recent account payments have failed or your spending limit needs to be increased. Please check the 'Billing & plans' section in your settings
```

I'm reminded that such "larger runners" are only available for organizations and enterprises using the GitHub Team or GitHub Enterprise Cloud plans, not common slobs like me. So I'm just dropping it from the list so I don't waste time trying it in the future.