### PR TITLE
Update Windows workflow for reliability and windows-2025 support

### DIFF
--- a/.github/workflows/ngrok-windows.yml
+++ b/.github/workflows/ngrok-windows.yml
@@ -2,16 +2,72 @@ name: "ngrok SSH tunnel (Windows)"
 
 on:
   workflow_dispatch:
+    inputs:
+      run-on:
+        description: 'Windows runner image to use'
+        required: true
+        default: 'windows-2022'
+        type: choice
+        options:
+        - windows-2022
+        - windows-2025
 
 jobs:
   ngrok_ssh_tunnel:
-    runs-on: windows-2019
+    runs-on: ${{ github.event.inputs.run-on }}
     steps:
       - uses: actions/checkout@v3
-      - name: Install Choco and SSH server
+
+      - name: Install/Enable SSH server
         run: |
-          choco install -y openssh -params '"/SSHServerFeature /KeyBasedAuthenticationFeature"'
+          $osVersion = (Get-CimInstance Win32_OperatingSystem).Caption
+          Write-Host "Operating System: $osVersion"
+
+          if ($osVersion -like "*2025*") {
+            Write-Host "=== Windows Server 2025 detected - OpenSSH is pre-installed ==="
+
+            # On Windows Server 2025, OpenSSH is pre-installed but not enabled
+            # Start and enable the SSH service
+            Start-Service sshd
+            Set-Service -Name sshd -StartupType 'Automatic'
+
+            Write-Host "SSH service started and set to automatic startup"
+          }
+          else {
+            Write-Host "=== Windows Server 2022 or earlier - Installing OpenSSH via Chocolatey ==="
+
+            # On Windows Server 2022 and earlier, use Chocolatey
+            choco install -y openssh -params '"/SSHServerFeature /KeyBasedAuthenticationFeature"'
+          }
         shell: powershell
+
+      - name: Configure Windows Firewall for SSH
+        run: |
+          # Create firewall rule to allow inbound SSH on port 22
+          New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' `
+            -DisplayName 'OpenSSH Server (sshd)' `
+            -Enabled True `
+            -Direction Inbound `
+            -Protocol TCP `
+            -Action Allow `
+            -LocalPort 22 `
+            -Profile Any -ErrorAction SilentlyContinue
+
+          # Verify the firewall rule was created
+          Write-Host "=== Firewall Rule ==="
+          Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' | Select-Object Name, Enabled, Direction, Action
+
+          # Verify sshd is running
+          Write-Host "`n=== SSHD Service Status ==="
+          Get-Service sshd
+
+          # Check what's listening on port 22
+          Write-Host "`n=== Listening on Port 22 ==="
+          netstat -an | Select-String ":22 "
+
+          Write-Host "`n=== SSH server is ready ==="
+        shell: powershell
+
       - name: Start SSH via ngrok
         run: |
           echo 'C:\msys64\usr\bin' >> $GITHUB_PATH
@@ -20,6 +76,7 @@ jobs:
           NGROK_TOKEN: ${{ secrets.NGROK_TOKEN }}
           USER_PASS: ${{ secrets.NGROK_PASS }}
         shell: bash
+
       - name: Keep tunnel alive for 24 hours
         run: sleep 86400
         shell: bash


### PR DESCRIPTION
After having recently updated the Workflows for both the Ubuntu and macOS runners, I gave the Windows one a spin and found it wasn't working. A few things are updated here:

1. The `windows-2019` runner it was previously hard-coded to use has been retired, so that's dropped.

2. On `windows-2022`, at first it seemed to be failing intermittently. The job would run ok, but when I went to SSH into the Runner using the generated command line, it would just hang and never prompt me for a password. When I consulted with Claude AI it was of the belief that it was caused by Windows firewall issues such that potentially the appropriate port would be opened such that my attempt to SSH in would succeed and sometimes it wouldn't. I can't vouch for this personally, but suffice to say after all the iterations Claude had me tried I can now say I just tested it out successfully and it worked 5 out of 5 times, so I'm happy to stick with what's here.

3. When I tried it for the first time with the `windows-2025` Runner, the job itself failed. I turned once again to Claude that claimed Windows 2025 dropped the `wmic` tool that Chocolatey uses for installation, but Windows 2025 apparently comes with OpenSSH, so the workflow is flexible to that and only tries to install Chocolatey on `windows-2022` runners.

4. Like with the Ubuntu and macOS Workflows, the Windows workflow now has a drop-down input picker that allows for selecting between those two available Runner types.

With the merge of this PR all of Ubuntu, macOS, and Windows have drop-down pickers for the available runners and has been tested to run successfully on all of them, so hopefully this repo will remain usable for a while in this state.